### PR TITLE
Rename classes and update messenger bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python -m spacy download en_core_web_sm
 
 ## Quickstart Guide
 
-The following example shows how to initialize a searcher and build a CQR agent from scratch using HQE and T5 as first-stage retrievers, and a BERT reranker. To see a working example agent, see [chatty_goose/agents/cqragent.py](chatty_goose/agents/cqragent.py).
+The following example shows how to initialize a searcher and build a CQR agent from scratch using HQE and T5 as first-stage retrievers, and a BERT reranker. To see a working example agent, see [chatty_goose/agents/chat.py](chatty_goose/agents/chat.py).
 
 First, load a searcher
 
@@ -86,16 +86,16 @@ pip install -r requirements.txt
 
 ## Example Agent
 
-To run an interactive conversational search agent with ParlAI, simply run [`cqragent.py`](chatty_goose/agents/cqragent.py). By default, we use the CAsT 2019 pre-built Pyserini index, but it is possible to specify other indexes using the `--from_prebuilt` flag. See the file for other possible arguments:
+To run an interactive conversational search agent with ParlAI, simply run [`chat.py`](chatty_goose/agents/chat.py). By default, we use the CAsT 2019 pre-built Pyserini index, but it is possible to specify other indexes using the `--from_prebuilt` flag. See the file for other possible arguments:
 
 ```
-python -m chatty_goose.agents.cqragent
+python -m chatty_goose.agents.chat
 ```
 
 Alternatively, run the agent using ParlAI's command line interface:
 
 ```
-python -m parlai interactive --model chatty_goose.agents.cqragent:ChattyGooseAgent
+python -m parlai interactive --model chatty_goose.agents.chat:ChattyGooseAgent
 ```
 
 We also provide instructions to deploy the agent to Facebook Messenger using ParlAI under [`examples/messenger`](examples/messenger/README.md).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python -m spacy download en_core_web_sm
 
 ## Quickstart Guide
 
-The following example shows how to initialize a searcher and build a CQR agent from scratch using HQE and T5 as first-stage retrievers, and a BERT reranker. To see a working example agent, see [chatty_goose/agents/chat.py](chatty_goose/agents/chat.py).
+The following example shows how to initialize a searcher and build a `ConversationalQueryRewriter` agent from scratch using HQE and T5 as first-stage retrievers, and a BERT reranker. To see a working example agent, see [chatty_goose/agents/chat.py](chatty_goose/agents/chat.py).
 
 First, load a searcher
 
@@ -45,11 +45,11 @@ searcher.set_bm25(0.82, 0.68)
 Next, initialize one or more first-stage CQR retrievers
 
 ```
-from chatty_goose.cqr import HQE, T5_NTR
-from chatty_goose.settings import HQESettings, T5Settings
+from chatty_goose.cqr import Hqe, Ntr
+from chatty_goose.settings import HqeSettings, NtrSettings
 
-hqe = HQE(searcher, HQESettings())
-t5 = T5_NTR(T5Settings())
+hqe = Hqe(searcher, HqeSettings())
+ntr = Ntr(NtrSettings())
 ```
 
 Load a reranker
@@ -65,7 +65,7 @@ Create a new `RetrievalPipeline`
 ```
 from chatty_goose.pipeline import RetrievalPipeline
 
-rp = RetrievalPipeline(searcher, [hqe, t5], searcher_num_hits=10, reranker=reranker)
+rp = RetrievalPipeline(searcher, [hqe, ntr], searcher_num_hits=50, reranker=reranker)
 ```
 
 And we're done! Simply call `rp.retrieve(query)` to retrieve passages, or call `rp.reset_history()` to reset the conversational history of the retrievers.

--- a/chatty_goose/agents/chat.py
+++ b/chatty_goose/agents/chat.py
@@ -1,9 +1,9 @@
 import logging
 
-from chatty_goose.cqr import HQE, T5_NTR
+from chatty_goose.cqr import Hqe, Ntr
 from chatty_goose.pipeline import RetrievalPipeline
-from chatty_goose.settings import HQESettings, T5Settings
-from chatty_goose.types import CQRType, PosFilter
+from chatty_goose.settings import HqeSettings, NtrSettings
+from chatty_goose.types import CqrType, PosFilter
 from parlai.core.agents import Agent, register_agent
 from pyserini.search import SimpleSearcher
 
@@ -38,7 +38,7 @@ class ChattyGooseAgent(Agent):
         super().__init__(opt, shared)
         self.name = opt["name"]
         self.episode_done = opt["episode_done"]
-        self.cqr_type = CQRType(opt["cqr_type"])
+        self.cqr_type = CqrType(opt["cqr_type"])
 
         # Initialize searcher
         searcher = SimpleSearcher.from_prebuilt_index(opt["from_prebuilt"])
@@ -46,8 +46,8 @@ class ChattyGooseAgent(Agent):
 
         # Initialize retrievers
         retrievers = []
-        if self.cqr_type == CQRType.HQE or self.cqr_type == CQRType.FUSION:
-            hqe_settings = HQESettings(
+        if self.cqr_type == CqrType.HQE or self.cqr_type == CqrType.FUSION:
+            hqe_settings = HqeSettings(
                 M=opt["M"],
                 eta=opt["eta"],
                 R_topic=opt["R_topic"],
@@ -55,11 +55,11 @@ class ChattyGooseAgent(Agent):
                 filter=PosFilter(opt["filter"]),
                 verbose=opt["verbose"],
             )
-            hqe = HQE(searcher, hqe_settings)
+            hqe = Hqe(searcher, hqe_settings)
             retrievers.append(hqe)
-        if self.cqr_type == CQRType.T5 or self.cqr_type == CQRType.FUSION:
-            t5_settings = T5Settings(model_name=opt["from_pretrained"], verbose=opt["verbose"])
-            t5 = T5_NTR(t5_settings)
+        if self.cqr_type == CqrType.T5 or self.cqr_type == CqrType.FUSION:
+            t5_settings = NtrSettings(model_name=opt["from_pretrained"], verbose=opt["verbose"])
+            t5 = Ntr(t5_settings)
             retrievers.append(t5)
 
         self.rp = RetrievalPipeline(searcher, retrievers, int(opt["hits"]))

--- a/chatty_goose/agents/chat.py
+++ b/chatty_goose/agents/chat.py
@@ -15,7 +15,7 @@ class ChattyGooseAgent(Agent):
         parser.add_argument('--name', type=str, default='CQR', help="The agent's name.")
         parser.add_argument('--cqr_type', type=str, default='fusion', help="hqe, t5, or fusion")
         parser.add_argument('--episode_done', type=str, default='[END]', help="end signal for interactive mode")
-        parser.add_argument('--hits', type=int, default=10, help="number of hits to retrieve from searcher")
+        parser.add_argument('--hits', type=int, default=50, help="number of hits to retrieve from searcher")
 
         # Pyserini
         parser.add_argument('--k1', default=0.82, help='BM25 k1 parameter')

--- a/chatty_goose/cqr/cqr.py
+++ b/chatty_goose/cqr/cqr.py
@@ -2,10 +2,10 @@ from abc import abstractmethod
 import logging
 
 
-__all__ = ["CQR"]
+__all__ = ["ConversationalQueryRewriter"]
 
 
-class CQR:
+class ConversationalQueryRewriter:
     """Base conversational query reformulation class"""
     def __init__(self, name: str, verbose: bool = False):
         self.name = name

--- a/chatty_goose/cqr/hqe.py
+++ b/chatty_goose/cqr/hqe.py
@@ -3,22 +3,22 @@ import re
 import time
 
 import spacy
-from chatty_goose.settings import HQESettings
+from chatty_goose.settings import HqeSettings
 from pyserini.search import SimpleSearcher
 
-from .cqr import CQR
+from .cqr import ConversationalQueryRewriter
 
-__all__ = ["HQE"]
+__all__ = ["Hqe"]
 
 nlp = spacy.load("en_core_web_sm")
 STOP_WORDS = nlp.Defaults.stop_words
 
 
-class HQE(CQR):
+class Hqe(ConversationalQueryRewriter):
     """Historical Query Expansion for conversational query reformulation"""
 
-    def __init__(self, searcher: SimpleSearcher, settings: HQESettings = HQESettings()):
-        super().__init__("HQE", verbose=settings.verbose)
+    def __init__(self, searcher: SimpleSearcher, settings: HqeSettings = HqeSettings()):
+        super().__init__("Hqe", verbose=settings.verbose)
 
         # Model settings
         self.M = settings.M

--- a/chatty_goose/cqr/hqe.py
+++ b/chatty_goose/cqr/hqe.py
@@ -10,8 +10,7 @@ from .cqr import CQR
 
 __all__ = ["HQE"]
 
-nlp = spacy.load("en_core_web_sm", parser=False, ner=False, textcat=False)
-nlp.pipeline = [nlp.pipeline[0]]
+nlp = spacy.load("en_core_web_sm")
 STOP_WORDS = nlp.Defaults.stop_words
 
 
@@ -39,7 +38,8 @@ class HQE(CQR):
         self.key_word_extraction(query)
         if self.turn_id != 0:
             hits = self.searcher.search(query, 1)
-            key_word = self.query_expansion(self.key_word_list, 0, self.turn_id)
+            key_word = self.query_expansion(
+                self.key_word_list, 0, self.turn_id)
             subkey_word = ""
             if len(hits) == 0 or hits[0].score <= self.eta:
                 end_turn = self.turn_id + 1

--- a/chatty_goose/cqr/ntr.py
+++ b/chatty_goose/cqr/ntr.py
@@ -2,20 +2,20 @@ import logging
 import time
 import torch
 
-from chatty_goose.settings import T5Settings
+from chatty_goose.settings import NtrSettings
 from spacy.lang.en import English
 from transformers import T5ForConditionalGeneration, T5Tokenizer
 
-from .cqr import CQR
+from .cqr import ConversationalQueryRewriter
 
-__all__ = ["T5_NTR"]
+__all__ = ["Ntr"]
 
 
-class T5_NTR(CQR):
+class Ntr(ConversationalQueryRewriter):
     """Neural Transfer Reformulation using a trained T5 model"""
 
-    def __init__(self, settings: T5Settings = T5Settings(), device: str = None):
-        super().__init__("T5", verbose=settings.verbose)
+    def __init__(self, settings: NtrSettings = NtrSettings(), device: str = None):
+        super().__init__("Ntr", verbose=settings.verbose)
 
         # Model settings
         self.max_length = settings.max_length

--- a/chatty_goose/pipeline/retrieval_pipeline.py
+++ b/chatty_goose/pipeline/retrieval_pipeline.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List
 
-from chatty_goose.cqr import CQR
+from chatty_goose.cqr import ConversationalQueryRewriter
 from chatty_goose.util import reciprocal_rank_fusion
 from pygaggle.rerank.base import Query, Reranker, hits_to_texts
 from pyserini.search import JSimpleSearcherResult, SimpleSearcher
@@ -12,27 +12,27 @@ __all__ = ["RetrievalPipeline"]
 class RetrievalPipeline:
     """
     End-to-end conversational passage retrieval pipeline
-    
+
     Parameters:
         searcher (SimpleSearcher): Pyserini searcher for Lucene index
-        reformulators (List[CQR]): List of CQR methods to use for first-stage retrieval
+        reformulators (List[ConversationalQueryRewriter]): List of CQR methods to use for first-stage retrieval
         searcher_num_hits (int): number of hits returned by searcher - default 10
         early_fusion (bool): flag to perform fusion before second-stage retrieval - default True
         reranker (Reranker): optional reranker for second-stage retrieval
         reranker_query_index (int): retriever index to use for reranking query - defaults to last retriever
-        reranker_query_reformulator (CQR): CQR method for generating reranker query,
-                                           overrides reranker_query_index if provided
+        reranker_query_reformulator (ConversationalQueryRewriter): CQR method for generating reranker query,
+                                                                   overrides reranker_query_index if provided
     """
 
     def __init__(
         self,
         searcher: SimpleSearcher,
-        reformulators: List[CQR],
+        reformulators: List[ConversationalQueryRewriter],
         searcher_num_hits: int = 10,
         early_fusion: bool = True,
         reranker: Reranker = None,
         reranker_query_index: int = -1,
-        reranker_query_reformulator: CQR = None,
+        reranker_query_reformulator: ConversationalQueryRewriter = None,
     ):
         self.searcher = searcher
         self.reformulators = reformulators
@@ -67,7 +67,8 @@ class RetrievalPipeline:
 
         # Rerank results
         if self.early_fusion:
-            results = self.rerank(rerank_query, cqr_hits[:self.searcher_num_hits])
+            results = self.rerank(
+                rerank_query, cqr_hits[:self.searcher_num_hits])
         else:
             # Rerank all CQR results and fuse together
             results = []

--- a/chatty_goose/settings.py
+++ b/chatty_goose/settings.py
@@ -2,13 +2,13 @@ from pydantic import BaseSettings
 
 from chatty_goose.types import PosFilter
 
-__all__ = ["SearcherSettings", "HQESettings", "T5Settings"]
+__all__ = ["SearcherSettings", "HqeSettings", "NtrSettings"]
 
 
 class SearcherSettings(BaseSettings):
     """Settings for Anserini searcher"""
 
-    index_path: str  # Pre-built index name or path to Lucene index 
+    index_path: str  # Pre-built index name or path to Lucene index
     k1: float = 0.82  # BM25 k parameter
     b: float = 0.68  # BM25 b parameter
     rm3: bool = False  # use RM3
@@ -17,11 +17,11 @@ class SearcherSettings(BaseSettings):
     original_query_weight: float = 0.8  # RM3 weigh to assign initial query
 
 
-class CQRSettings(BaseSettings):
+class CqrSettings(BaseSettings):
     verbose: bool = False
 
 
-class HQESettings(CQRSettings):
+class HqeSettings(CqrSettings):
     """Settings for HQE with defaults tuned on CAsT"""
 
     M: int = 5  # number of aggregate historical queries
@@ -31,7 +31,7 @@ class HQESettings(CQRSettings):
     filter: PosFilter = PosFilter.POS  # 'no' or 'pos' or 'stp'
 
 
-class T5Settings(CQRSettings):
+class NtrSettings(CqrSettings):
     """Settings for T5 model for NTR"""
 
     model_name: str = "castorini/t5-base-canard"

--- a/chatty_goose/types.py
+++ b/chatty_goose/types.py
@@ -6,7 +6,7 @@ class PosFilter(str, Enum):
     POS = "pos"
     STP = "stp"
 
-class CQRType(str, Enum):
+class CqrType(str, Enum):
     HQE = "hqe"
     T5 = "t5"
     FUSION = "fusion"

--- a/examples/messenger/config.yml
+++ b/examples/messenger/config.yml
@@ -13,6 +13,6 @@ opt:
   password: ChattyGoose
   models:
     chatty_goose:
-      model: chatty_goose.agents.cqragent:ChattyGooseAgent
+      model: chatty_goose.agents.chat:ChattyGooseAgent
 additional_args:
   page_id: ChattyGooseIR # Configure for custom page

--- a/examples/messenger/config.yml
+++ b/examples/messenger/config.yml
@@ -1,6 +1,6 @@
 tasks:
   default:
-    onboard_world: ChattyGooeMessengerOnboardWorld
+    onboard_world: ChattyGooseMessengerOnboardWorld
     task_world: ChattyGooseMessengerTaskWorld
     timeout: 180
     agents_required: 1

--- a/examples/messenger/worlds.py
+++ b/examples/messenger/worlds.py
@@ -3,14 +3,14 @@ from parlai.chat_service.services.messenger.worlds import OnboardWorld
 from parlai.core.agents import create_agent_from_shared
 
 
-class ChattyGooeMessengerOnboardWorld(OnboardWorld):
+class ChattyGooseMessengerOnboardWorld(OnboardWorld):
     """
     Example messenger onboarding world for Chatty Goose.
     """
 
     @staticmethod
     def generate_world(opt, agents):
-        return ChattyGooeMessengerOnboardWorld(opt=opt, agent=agents[0])
+        return ChattyGooseMessengerOnboardWorld(opt=opt, agent=agents[0])
 
     def parley(self):
         self.episodeDone = True
@@ -61,10 +61,13 @@ class ChattyGooseMessengerTaskWorld(World):
                 self.episodeDone = True
             elif '[RESET]' in a['text']:
                 self.model.reset()
-                self.agent.observe({"text": "[History Cleared]", "episode_done": False})
+                self.agent.observe(
+                    {"text": "[History Cleared]", "episode_done": False})
             else:
                 self.model.observe(a)
                 response = self.model.act()
+                # Make sure prefix from agent is not displayed
+                response.force_set('id', '')
                 self.agent.observe(response)
 
     def episode_done(self):

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -2,10 +2,10 @@ import argparse
 import json
 import time
 
-from chatty_goose.cqr import HQE, T5_NTR
+from chatty_goose.cqr import Hqe, Ntr
 from chatty_goose.pipeline import RetrievalPipeline
-from chatty_goose.settings import HQESettings, SearcherSettings, T5Settings
-from chatty_goose.types import CQRType, PosFilter
+from chatty_goose.settings import HqeSettings, SearcherSettings, NtrSettings
+from chatty_goose.types import CqrType, PosFilter
 from chatty_goose.util import build_bert_reranker, build_searcher
 
 
@@ -103,7 +103,7 @@ def run_experiment(rp: RetrievalPipeline):
 
 if __name__ == "__main__":
     args = parse_experiment_args()
-    experiment = CQRType(args.experiment)
+    experiment = CqrType(args.experiment)
 
     searcher_settings = SearcherSettings(
         index_path=args.index,
@@ -121,8 +121,8 @@ if __name__ == "__main__":
     reranker_query_reformulator = None
     reranker = build_bert_reranker(device=args.reranker_device) if args.rerank else None
 
-    if experiment == CQRType.HQE or experiment == CQRType.FUSION:
-        hqe_bm25_settings = HQESettings(
+    if experiment == CqrType.HQE or experiment == CqrType.FUSION:
+        hqe_bm25_settings = HqeSettings(
             M=args.M0,
             eta=args.eta0,
             R_topic=args.R0_topic,
@@ -130,30 +130,30 @@ if __name__ == "__main__":
             filter=PosFilter(args.filter),
             verbose=args.verbose,
         )
-        hqe_bm25 = HQE(searcher, hqe_bm25_settings)
+        hqe_bm25 = Hqe(searcher, hqe_bm25_settings)
         reformulators.append(hqe_bm25)
 
-    if experiment == CQRType.T5 or experiment == CQRType.FUSION:
-        # Initialize T5
-        t5_settings = T5Settings(
+    if experiment == CqrType.T5 or experiment == CqrType.FUSION:
+        # Initialize T5 NTR
+        t5_settings = NtrSettings(
             model_name=args.t5_model_name,
             max_length=args.max_length,
             num_beams=args.num_beams,
             early_stopping=not args.no_early_stopping,
             verbose=args.verbose,
         )
-        t5 = T5_NTR(t5_settings, device=args.t5_device)
+        t5 = Ntr(t5_settings, device=args.t5_device)
         reformulators.append(t5)
 
-    if experiment == CQRType.HQE:
-        hqe_bert_settings = HQESettings(
+    if experiment == CqrType.HQE:
+        hqe_bert_settings = HqeSettings(
             M=args.M1,
             eta=args.eta1,
             R_topic=args.R1_topic,
             R_sub=args.R1_sub,
             filter=PosFilter(args.filter),
         )
-        reranker_query_reformulator = HQE(searcher, hqe_bert_settings)
+        reranker_query_reformulator = Hqe(searcher, hqe_bert_settings)
 
     rp = RetrievalPipeline(
         searcher,


### PR DESCRIPTION
*Breaking changes*:

Renamed several classes to follow Python conventions / be more consistent
- `chatty_goose.agents.cqragent` -> `chatty_goose.agents.chat`
- `HQE` -> `Hqe`
- `T5_NTR` -> `Ntr`
- `HQESettings` -> `HqeSettings`
- `T5Settings` -> `NtrSettings`
- `CQRType` -> `CqrType`
- `CQRSettings` -> `CqrSettings`
- `CQR` -> `ConversationalQueryRewriter`
