### PR TITLE
Restrict SpaCy version and update package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ coloredlogs
 parlai==1.1.0
 pydantic>=1.5
 pygaggle==0.0.3.1
-spacy>=2.2.4
+spacy>=2.2.4,<=2.3.5

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ excluded = ["data*", "examples*", "experiments*"]
 
 setuptools.setup(
     name="chatty-goose",
-    version="0.1.0",
+    version="0.2.0",
     author="Anserini Gaggle",
     author_email="anserini.gaggle@gmail.com",
     description="A conversational passage retrieval toolkit",


### PR DESCRIPTION
* Bumping package version to 0.2.0 due to new breaking changes
* SpaCy version restricted to under Spacy 3.0.0 due to some errors with PyGaggle