### PR TITLE
CQR Replication

### DIFF
--- a/docs/cqr_experiments.md
+++ b/docs/cqr_experiments.md
@@ -46,3 +46,7 @@ Results for the CAsT 2019 evaluation dataset are provided below. The results may
 | Recall@1000 |  0.7322  |     0.7322      | 0.7392  |     0.7392     |   0.8028    |       0.8028       |
 | NDCG@1      |  0.2640  |     0.4745      | 0.2842  |     0.5751     |   0.3353    |       0.5838       |
 | NDCG@3      |  0.2606  |     0.4798      | 0.2954  |     0.5464     |   0.3247    |       0.5640       |
+
+## Reproduction Log[*](reproducibility.md)
+
++ Results reproduced by [@saileshnankani](https://github.com/saileshnankani) on 2021-05-17 (commit [`3847d15`](https://github.com/castorini/chatty-goose/commit/3847d15f3fb39a57ac061648c863798dd4510049)) (Fuson BM25)

--- a/docs/cqr_experiments.md
+++ b/docs/cqr_experiments.md
@@ -47,6 +47,6 @@ Results for the CAsT 2019 evaluation dataset are provided below. The results may
 | NDCG@1      |  0.2640  |     0.4745      | 0.2842  |     0.5751     |   0.3353    |       0.5838       |
 | NDCG@3      |  0.2606  |     0.4798      | 0.2954  |     0.5464     |   0.3247    |       0.5640       |
 
-## Reproduction Log[*](reproducibility.md)
+## Reproduction Log
 
 + Results reproduced by [@saileshnankani](https://github.com/saileshnankani) on 2021-05-17 (commit [`3847d15`](https://github.com/castorini/chatty-goose/commit/3847d15f3fb39a57ac061648c863798dd4510049)) (Fuson BM25)


### PR DESCRIPTION
Add CQR replication for `Fusion BM25`

Library versions used:
torch==1.7.0
torchvision==0.8.1
torchtext==0.8

------------

Results:

```
map                   	all	0.2584
recall_1000           	all	0.8028
ndcg_cut_1            	all	0.3353
ndcg_cut_3            	all	0.3247
```

Details and reproduction results can be found in the [notebook](https://colab.research.google.com/drive/1ZaZx7hqKbPkvuFBf6lLgCxGRooosIxbI?usp=sharing)