### PR TITLE
Add support for canonical response

### DIFF
--- a/chatty_goose/cqr/cqr.py
+++ b/chatty_goose/cqr/cqr.py
@@ -7,6 +7,7 @@ __all__ = ["ConversationalQueryRewriter"]
 
 class ConversationalQueryRewriter:
     """Base conversational query reformulation class"""
+
     def __init__(self, name: str, verbose: bool = False):
         self.name = name
         self.turn_id: int = -1
@@ -14,7 +15,7 @@ class ConversationalQueryRewriter:
         self.verbose: bool = verbose
 
     @abstractmethod
-    def rewrite(self, query: str) -> str:
+    def rewrite(self, query: str, context: str = None) -> str:
         """Rewrite original query text"""
         raise NotImplementedError
 

--- a/chatty_goose/cqr/cqr.py
+++ b/chatty_goose/cqr/cqr.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from abc import abstractmethod
 import logging
 
@@ -7,6 +8,7 @@ __all__ = ["ConversationalQueryRewriter"]
 
 class ConversationalQueryRewriter:
     """Base conversational query reformulation class"""
+
     def __init__(self, name: str, verbose: bool = False):
         self.name = name
         self.turn_id: int = -1
@@ -14,7 +16,7 @@ class ConversationalQueryRewriter:
         self.verbose: bool = verbose
 
     @abstractmethod
-    def rewrite(self, query: str, context: str = None) -> str:
+    def rewrite(self, query: str, context: Optional[str] = None) -> str:
         """Rewrite original query text"""
         raise NotImplementedError
 

--- a/chatty_goose/cqr/cqr.py
+++ b/chatty_goose/cqr/cqr.py
@@ -7,7 +7,6 @@ __all__ = ["ConversationalQueryRewriter"]
 
 class ConversationalQueryRewriter:
     """Base conversational query reformulation class"""
-
     def __init__(self, name: str, verbose: bool = False):
         self.name = name
         self.turn_id: int = -1

--- a/chatty_goose/cqr/hqe.py
+++ b/chatty_goose/cqr/hqe.py
@@ -1,6 +1,7 @@
 import collections
 import re
 import time
+from typing import Optional
 
 import spacy
 from chatty_goose.settings import HqeSettings
@@ -32,12 +33,10 @@ class Hqe(ConversationalQueryRewriter):
         self.key_word_list = collections.defaultdict(list)
         self.subkey_word_list = collections.defaultdict(list)
 
-    def rewrite(self, query: str, context: str = None) -> str:
+    def rewrite(self, query: str, context: Optional[str] = None) -> str:
         start_time = time.time()
         self.turn_id += 1
-        if context:
-            self.key_word_extraction(context)
-        self.key_word_extraction(query)
+        self.key_word_extraction(context+" "+query if context else query)
         if self.turn_id != 0:
             hits = self.searcher.search(query, 1)
             key_word = self.query_expansion(

--- a/chatty_goose/cqr/hqe.py
+++ b/chatty_goose/cqr/hqe.py
@@ -35,6 +35,8 @@ class Hqe(ConversationalQueryRewriter):
     def rewrite(self, query: str, context: str = None) -> str:
         start_time = time.time()
         self.turn_id += 1
+        if context:
+            self.key_word_extraction(context)
         self.key_word_extraction(query)
         if self.turn_id != 0:
             hits = self.searcher.search(query, 1)

--- a/chatty_goose/cqr/hqe.py
+++ b/chatty_goose/cqr/hqe.py
@@ -32,7 +32,7 @@ class Hqe(ConversationalQueryRewriter):
         self.key_word_list = collections.defaultdict(list)
         self.subkey_word_list = collections.defaultdict(list)
 
-    def rewrite(self, query: str) -> str:
+    def rewrite(self, query: str, context: str = None) -> str:
         start_time = time.time()
         self.turn_id += 1
         self.key_word_extraction(query)

--- a/chatty_goose/cqr/ntr.py
+++ b/chatty_goose/cqr/ntr.py
@@ -43,7 +43,7 @@ class Ntr(ConversationalQueryRewriter):
 
         # If the passage from canonical result (context) is provided, it is added to history.
         # Since canonical passage can be large and there is limit on length of tokens,
-        # only passage for most recent query is used at a time.
+        # only one passage for the new query is used at a time.
         if len(self.history) >= 2 and self.has_canonical_context:
             self.history.pop(-2)
             self.has_canonical_context = False

--- a/chatty_goose/cqr/ntr.py
+++ b/chatty_goose/cqr/ntr.py
@@ -41,11 +41,12 @@ class Ntr(ConversationalQueryRewriter):
         start_time = time.time()
         self.turn_id += 1
 
-        # Removes previously added canonical passage due to token limit
+        # The passage from canonical result (context) is added to history if it is provided.
+        # Since canonical passage can be large and there is limit on length of tokens,
+        # only passage for most recent query is used at a time.
         if len(self.history) >= 2 and self.has_canonical_context:
             self.history.pop(-2)
             self.has_canonical_context = False
-
         if context:
             self.history += [context]
             self.has_canonical_context = True

--- a/chatty_goose/cqr/ntr.py
+++ b/chatty_goose/cqr/ntr.py
@@ -45,7 +45,7 @@ class Ntr(ConversationalQueryRewriter):
         src_text = " ||| ".join(self.history)
         src_text = " ".join([tok.text for tok in self.nlp(src_text)])
         input_ids = self.tokenizer(
-            src_text, return_tensors="pt", add_special_tokens=True
+            src_text, return_tensors="pt", add_special_tokens=True, max_length=512, truncation=True
         ).input_ids.to(self.device)
 
         # Generate new sequence

--- a/chatty_goose/cqr/ntr.py
+++ b/chatty_goose/cqr/ntr.py
@@ -41,7 +41,7 @@ class Ntr(ConversationalQueryRewriter):
         start_time = time.time()
         self.turn_id += 1
 
-        # The passage from canonical result (context) is added to history if it is provided.
+        # If the passage from canonical result (context) is provided, it is added to history.
         # Since canonical passage can be large and there is limit on length of tokens,
         # only passage for most recent query is used at a time.
         if len(self.history) >= 2 and self.has_canonical_context:

--- a/chatty_goose/cqr/ntr.py
+++ b/chatty_goose/cqr/ntr.py
@@ -44,6 +44,7 @@ class Ntr(ConversationalQueryRewriter):
         # Build input sequence from query and history
         if len(self.history) >= 2 and self.has_context:
             self.history.pop(-2)
+            self.has_context = False
         if context:
             self.history += [context]
             self.has_context = True

--- a/chatty_goose/cqr/ntr.py
+++ b/chatty_goose/cqr/ntr.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import torch
+from typing import Optional
 
 from chatty_goose.settings import NtrSettings
 from spacy.lang.en import English
@@ -37,7 +38,7 @@ class Ntr(ConversationalQueryRewriter):
         self.history = []
         self.has_canonical_context = False
 
-    def rewrite(self, query: str, context: str = None) -> str:
+    def rewrite(self, query: str, context: Optional[str] = None) -> str:
         start_time = time.time()
         self.turn_id += 1
 

--- a/chatty_goose/cqr/ntr.py
+++ b/chatty_goose/cqr/ntr.py
@@ -35,19 +35,22 @@ class Ntr(ConversationalQueryRewriter):
         self.tokenizer = T5Tokenizer.from_pretrained(settings.model_name)
         self.nlp = English()
         self.history = []
-        self.has_context = False
+        self.has_canonical_context = False
 
     def rewrite(self, query: str, context: str = None) -> str:
         start_time = time.time()
         self.turn_id += 1
 
-        # Build input sequence from query and history
-        if len(self.history) >= 2 and self.has_context:
+        # Removes previously added canonical passage due to token limit
+        if len(self.history) >= 2 and self.has_canonical_context:
             self.history.pop(-2)
-            self.has_context = False
+            self.has_canonical_context = False
+
         if context:
             self.history += [context]
-            self.has_context = True
+            self.has_canonical_context = True
+
+        # Build input sequence from query and history
         self.history += [query]
         src_text = " ||| ".join(self.history)
         src_text = " ".join([tok.text for tok in self.nlp(src_text)])

--- a/chatty_goose/cqr/ntr.py
+++ b/chatty_goose/cqr/ntr.py
@@ -36,11 +36,15 @@ class Ntr(ConversationalQueryRewriter):
         self.nlp = English()
         self.history = []
 
-    def rewrite(self, query: str) -> str:
+    def rewrite(self, query: str, context: str = None) -> str:
         start_time = time.time()
         self.turn_id += 1
 
         # Build input sequence from query and history
+        if context:
+            if len(self.history) >= 2:
+                self.history.pop(-2)
+            self.history += [context]
         self.history += [query]
         src_text = " ||| ".join(self.history)
         src_text = " ".join([tok.text for tok in self.nlp(src_text)])

--- a/chatty_goose/pipeline/retrieval_pipeline.py
+++ b/chatty_goose/pipeline/retrieval_pipeline.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 from chatty_goose.cqr import ConversationalQueryRewriter
 from chatty_goose.util import reciprocal_rank_fusion
@@ -33,6 +33,7 @@ class RetrievalPipeline:
         reranker: Reranker = None,
         reranker_query_index: int = -1,
         reranker_query_reformulator: ConversationalQueryRewriter = None,
+        context_searcher: Optional[SimpleSearcher] = None,
     ):
         self.searcher = searcher
         self.reformulators = reformulators
@@ -41,6 +42,7 @@ class RetrievalPipeline:
         self.reranker = reranker
         self.reranker_query_index = reranker_query_index
         self.reranker_query_reformulator = reranker_query_reformulator
+        self.context_searcher = context_searcher
 
     def retrieve(self, query, context: str = None) -> List[JSimpleSearcherResult]:
         cqr_hits = []

--- a/chatty_goose/pipeline/retrieval_pipeline.py
+++ b/chatty_goose/pipeline/retrieval_pipeline.py
@@ -1,5 +1,6 @@
 import logging
-from typing import List, Optional
+import json
+from typing import List, Optional, Union
 
 from chatty_goose.cqr import ConversationalQueryRewriter
 from chatty_goose.util import reciprocal_rank_fusion
@@ -44,7 +45,7 @@ class RetrievalPipeline:
         self.reranker_query_reformulator = reranker_query_reformulator
         self.context_searcher = context_searcher
 
-    def retrieve(self, query, context: str = None) -> List[JSimpleSearcherResult]:
+    def retrieve(self, query, context: Optional[str] = None) -> List[JSimpleSearcherResult]:
         cqr_hits = []
         cqr_queries = []
         for cqr in self.reformulators:
@@ -99,3 +100,11 @@ class RetrievalPipeline:
 
         if self.reranker_query_reformulator:
             self.reranker_query_reformulator.reset_history()
+
+    def get_context(self, docid: Union[str, int]) -> Optional[str]:
+        if not self.context_searcher:
+            return None
+        doc = self.context_searcher.doc(docid)
+        if doc is not None:
+            return json.loads(doc.raw())['contents']
+        return None

--- a/chatty_goose/pipeline/retrieval_pipeline.py
+++ b/chatty_goose/pipeline/retrieval_pipeline.py
@@ -42,11 +42,11 @@ class RetrievalPipeline:
         self.reranker_query_index = reranker_query_index
         self.reranker_query_reformulator = reranker_query_reformulator
 
-    def retrieve(self, query) -> List[JSimpleSearcherResult]:
+    def retrieve(self, query, context=None) -> List[JSimpleSearcherResult]:
         cqr_hits = []
         cqr_queries = []
         for cqr in self.reformulators:
-            new_query = cqr.rewrite(query)
+            new_query = cqr.rewrite(query, context)
             hits = self.searcher.search(new_query, k=self.searcher_num_hits)
             cqr_hits.append(hits)
             cqr_queries.append(new_query)

--- a/chatty_goose/pipeline/retrieval_pipeline.py
+++ b/chatty_goose/pipeline/retrieval_pipeline.py
@@ -42,7 +42,7 @@ class RetrievalPipeline:
         self.reranker_query_index = reranker_query_index
         self.reranker_query_reformulator = reranker_query_reformulator
 
-    def retrieve(self, query, context=None) -> List[JSimpleSearcherResult]:
+    def retrieve(self, query, context: str = None) -> List[JSimpleSearcherResult]:
         cqr_hits = []
         cqr_queries = []
         for cqr in self.reformulators:

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -80,7 +80,7 @@ def run_experiment(rp: RetrievalPipeline):
                     qr_start_time = time.time()
                     qr_total_time += time.time() - qr_start_time
 
-                    if args.context_field:
+                    if args.context_index:
                         docid = conversations[args.context_field].split('_')[-1]
                         manual_context_buffer[turn_id] = rp.get_context(docid)
 

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -71,7 +71,7 @@ def run_experiment(rp: RetrievalPipeline):
             for session in data:
                 session_num = str(session["number"])
                 start_time = time.time()
-                manual_context_buffer = [None for i in range(len(session))]
+                manual_context_buffer = [None for i in range(len(session["turn"]))]
 
                 for turn_id, conversations in enumerate(session["turn"]):
                     query = conversations["raw_utterance"]

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -80,17 +80,17 @@ def run_experiment(rp: RetrievalPipeline):
                     qr_start_time = time.time()
                     qr_total_time += time.time() - qr_start_time
 
+                    context = None
+
                     if conversations.get("manual_canonical_result_id", None):
                         doc_id = conversations["manual_canonical_result_id"].split('_')[1]
                         doc = searcher.doc(doc_id)
-                        if doc is None:
-                            continue
-
-                        context = json.loads(doc.raw())['contents']
-                        manual_context_buffer.append(context)
-
+                        if doc is not None:
+                            context = json.loads(doc.raw())['contents']
+                            manual_context_buffer.append(context)
                     # use current query along with last 2 from buffer
-                    hits = rp.retrieve(query, manual_context_buffer[-1])
+                    hits = rp.retrieve(query, context)
+
                     for rank in range(len(hits)):
                         docno = hits[rank].docid
                         fout0.write("{}\t{}\t{}\n".format(qid, docno, rank + 1))

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -90,7 +90,7 @@ def run_experiment(rp: RetrievalPipeline):
                         manual_context_buffer.append(context)
 
                     # use current query along with last 2 from buffer
-                    hits = rp.retrieve((query+manual_context_buffer[-1]))
+                    hits = rp.retrieve(query, manual_context_buffer[-1])
                     for rank in range(len(hits)):
                         docno = hits[rank].docid
                         fout0.write("{}\t{}\t{}\n".format(qid, docno, rank + 1))

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -81,14 +81,13 @@ def run_experiment(rp: RetrievalPipeline):
                     qr_total_time += time.time() - qr_start_time
 
                     context = None
-
                     if conversations.get("manual_canonical_result_id", None):
                         doc_id = conversations["manual_canonical_result_id"].split('_')[1]
                         doc = searcher.doc(doc_id)
                         if doc is not None:
                             context = json.loads(doc.raw())['contents']
                             manual_context_buffer.append(context)
-                    # use current query along with last 2 from buffer
+
                     hits = rp.retrieve(query, context)
 
                     for rank in range(len(hits)):

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -80,8 +80,9 @@ def run_experiment(rp: RetrievalPipeline):
                     qr_start_time = time.time()
                     qr_total_time += time.time() - qr_start_time
 
-                    docid = conversations[args.context_field].split('_')[-1]
-                    manual_context_buffer[turn_id] = rp.get_context(docid)
+                    if args.context_field:
+                        docid = conversations[args.context_field].split('_')[-1]
+                        manual_context_buffer[turn_id] = rp.get_context(docid)
 
                     hits = rp.retrieve(query, manual_context_buffer[turn_id])
 

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -80,11 +80,8 @@ def run_experiment(rp: RetrievalPipeline):
                     qr_start_time = time.time()
                     qr_total_time += time.time() - qr_start_time
 
-                    if rp.context_searcher:
-                        doc_id = conversations[args.context_field].split('_')[1]
-                        doc = rp.context_searcher.doc(doc_id)
-                        if doc is not None:
-                            manual_context_buffer[turn_id] = json.loads(doc.raw())['contents']
+                    docid = conversations[args.context_field].split('_')[-1]
+                    manual_context_buffer[turn_id] = rp.get_context(docid)
 
                     hits = rp.retrieve(query, manual_context_buffer[turn_id])
 

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -85,7 +85,8 @@ def run_experiment(rp: RetrievalPipeline):
                         fout0.write("{}\t{}\t{}\n".format(qid, docno, rank + 1))
 
                     if conversations.get("manual_canonical_result_id", None):
-                        doc = conversations["manual_canonical_result_id"].split('_')[1]
+                        doc_id = conversations["manual_canonical_result_id"].split('_')[1]
+                        doc = searcher.doc(doc_id)
                         if doc is None:
                             continue
 

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -9,7 +9,7 @@ from chatty_goose.types import CqrType, PosFilter
 from chatty_goose.util import build_bert_reranker, build_searcher
 
 from pyserini.search import SimpleSearcher
-searcher = SimpleSearcher.from_prebuilt_index('msmarco-passage')
+searcher = SimpleSearcher.from_prebuilt_index('cast2019')
 
 
 def parse_experiment_args():
@@ -91,6 +91,7 @@ def run_experiment(rp: RetrievalPipeline):
                             continue
 
                         query = json.loads(doc.raw())['contents']
+                        print("query: ", query)
                         total_query_count += 1
 
                         conversation_num = str(conversations["number"])

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -90,7 +90,7 @@ def run_experiment(rp: RetrievalPipeline):
                         manual_context_buffer.append(context)
 
                     # use current query along with last 2 from buffer
-                    hits = rp.retrieve(query+manual_context_buffer[2:])
+                    hits = rp.retrieve((query+manual_context_buffer[-1]))
                     for rank in range(len(hits)):
                         docno = hits[rank].docid
                         fout0.write("{}\t{}\t{}\n".format(qid, docno, rank + 1))

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -9,7 +9,6 @@ from chatty_goose.types import CqrType, PosFilter
 from chatty_goose.util import build_bert_reranker, build_searcher
 
 from pyserini.search import SimpleSearcher
-searcher = SimpleSearcher.from_prebuilt_index('cast2019')
 
 
 def parse_experiment_args():
@@ -58,6 +57,7 @@ def parse_experiment_args():
 def run_experiment(rp: RetrievalPipeline):
     with open(args.output + ".tsv", "w") as fout0:
         with open(args.output + ".doc.tsv", "w") as fout1:
+            searcher = SimpleSearcher.from_prebuilt_index('msmarco-passage')
 
             total_query_count = 0
             with open(args.qid_queries) as json_file:
@@ -91,7 +91,6 @@ def run_experiment(rp: RetrievalPipeline):
                             continue
 
                         query = json.loads(doc.raw())['contents']
-                        print("query: ", query)
                         total_query_count += 1
 
                         conversation_num = str(conversations["number"])


### PR DESCRIPTION
This PR adds support for using `manual_canonical_result_id` in the [CAsT2020 data](https://github.com/daltonj/treccastweb/blob/master/2020/2020_manual_evaluation_topics_v1.0.json#L10) for both `ntr` and `hqe` (for #23). 

For `ntr`, `rewrite` uses the passage corresponding to the  canonical document in the history. We only use 1 passage in the  historical context as otherwise, it exceed 512 tokens limit. For e.g., it uses `q1/P1/q2` and then `q1/q2/P2/q3` and so on. 