### PR TITLE
Add chatty goose support for dense retrieval and hybrid search for T5 and CQE

### DIFF
--- a/chatty_goose/cqr/__init__.py
+++ b/chatty_goose/cqr/__init__.py
@@ -1,3 +1,4 @@
 from .hqe import *
 from .ntr import *
 from .cqr import *
+from .cqe import *

--- a/chatty_goose/cqr/cqe.py
+++ b/chatty_goose/cqr/cqe.py
@@ -1,0 +1,129 @@
+import logging
+import time
+import torch
+from typing import Optional
+from pyserini.search import querybuilder
+from transformers import BertModel, BertTokenizer, BertTokenizerFast
+from .cqr import ConversationalQueryRewriter
+from chatty_goose.settings import CqeSettings
+import numpy as np
+from numpy import linalg as LA
+
+name = "Cqe"
+__all__ = [name]
+
+
+class Cqe(ConversationalQueryRewriter):
+    """Neural Transfer Reformulation using a trained T5 model"""
+
+    def __init__(self, settings: CqeSettings = CqeSettings(), device: str = None):
+        super().__init__(name, verbose=settings.verbose)
+        self.name=name
+        # Model settings
+        if settings.model_name:
+            self.l2_threshold = settings.l2_threshold
+            self.max_query_length = settings.max_query_length
+            self.max_context_length = settings.max_context_length
+            self.max_length = self.max_query_length + self.max_context_length
+            device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+            self.device = torch.device(device)
+            if self.verbose:
+                logging.info(f"Initializing CQE using model {settings.model_name}...")
+            logging.info(f"Initializing CQE using model {settings.model_name}...")
+            self.model = BertModel.from_pretrained(settings.model_name)
+            self.model.to(self.device)
+            self.tokenizer = BertTokenizer.from_pretrained(settings.model_name)
+            self.has_model = True
+            self.history = []
+            self.has_canonical_context = False
+        if (not self.has_model):
+            raise Exception('Neither query encoder model nor encoded queries provided. Please provide at least one')
+
+    def rewrite(self, query: str, context: Optional[str] = None) -> str:
+        start_time = time.time()
+        self.turn_id += 1
+
+        # If the passage from canonical result (context) is provided, it is added to history.
+        # Since canonical passage can be large and there is limit on length of tokens,
+        # only one passage for the new query is used at a time.
+        if len(self.history) >= 2 and self.has_canonical_context:
+            self.history.pop(-2)
+            self.has_canonical_context = False
+        if context:
+            self.history += [context]
+            self.has_canonical_context = True
+
+        # Build input sequence from query and history
+        self.history += [query]
+        src_ctx = '[CLS] ' +"|".join(self.history[:-1])
+        src_q = ' [Q] ' + self.history[-1] + '[MASK]' * self.max_query_length
+        if self.turn_id == 0:
+            input_ids = self.tokenizer.encode('[CLS] ' +src_q, max_length=self.max_query_length, add_special_tokens=False)
+            token_type_ids =[0] + [1] * (len(input_ids)-1)
+            self.context_length = 3
+            effective_token_weights = [0]*4 + [1]*(self.max_query_length-4)
+        else:
+            src_ctx_token_ids = self.tokenizer.encode(src_ctx, max_length=self.max_context_length, add_special_tokens=False)
+            src_query_token_ids = self.tokenizer.encode(src_q, max_length=self.max_query_length, add_special_tokens=False)
+            input_ids = src_ctx_token_ids + src_query_token_ids
+            token_type_ids = [0]*len(src_ctx_token_ids) + [1]*len(src_query_token_ids)
+            self.context_length = len(src_ctx_token_ids) - 1 + 3
+            effective_token_weights = [0] + [1]*(len(src_ctx_token_ids)-1) + [0]*3 + [1]*(self.max_query_length-3)
+        input_tokens = []
+        for input_id in input_ids[1:]:
+            input_tokens.append(self.tokenizer.decode(input_id).replace(' ','') ) #transform whitepiece token into text by removing ' '
+
+        input_ids = torch.LongTensor([input_ids]).to(self.device)
+        token_type_ids = torch.LongTensor([token_type_ids]).to(self.device)
+        
+
+
+        outputs = self.model(input_ids=input_ids, token_type_ids=token_type_ids)
+        embeddings = outputs.last_hidden_state.detach().cpu().numpy()
+
+        self.query_embs =  np.average(embeddings, axis=1, weights=effective_token_weights).astype(np.float32)
+
+        # Generate reformulated query with term weight
+        query_token_weights = np.squeeze(LA.norm(embeddings[:,1:,:], axis=-1))
+        
+        rewrite_text = self.build_query(input_tokens, query_token_weights, self.l2_threshold)
+
+
+        self.total_latency += time.time() - start_time
+        return rewrite_text
+
+    def reset_history(self):
+        super().reset_history()
+        self.history = []
+
+    def build_query(self, query_tokens, query_token_weights, threshold):
+        context_token_num = self.context_length
+        mean_l2 = query_token_weights.mean()
+
+        should = querybuilder.JBooleanClauseOccur['should'].value
+        boolean_query_builder = querybuilder.get_boolean_query_builder()
+        is_context = True
+        term_weight = 0
+        term =''
+
+        for i, token in enumerate(query_tokens): 
+            if token == '[MASK]':
+
+                continue
+            if '##' in token:
+                term += token[2:]
+                term_weight = max(term_weight, query_token_weights[i])
+            else:
+                if ( (term_weight > threshold) or (i>=context_token_num)): #10.5, 12
+                    try:
+                        term = querybuilder.get_term_query(term)
+                        boost = querybuilder.get_boost_query(term, term_weight/mean_l2)
+                        boolean_query_builder.add(boost, should)
+                    except:
+                        pass
+
+                term = token
+                term_weight = query_token_weights[i]
+
+        return boolean_query_builder.build()
+

--- a/chatty_goose/cqr/hqe.py
+++ b/chatty_goose/cqr/hqe.py
@@ -5,11 +5,15 @@ from typing import Optional
 
 import spacy
 from chatty_goose.settings import HqeSettings
-from pyserini.search import SimpleSearcher
-
 from .cqr import ConversationalQueryRewriter
 
-__all__ = ["Hqe"]
+import sys 
+sys.path.append('../pyserini') 
+from pyserini.search import SimpleSearcher
+
+
+name = "Hqe"
+__all__ = [name]
 
 nlp = spacy.load("en_core_web_sm")
 STOP_WORDS = nlp.Defaults.stop_words
@@ -19,8 +23,8 @@ class Hqe(ConversationalQueryRewriter):
     """Historical Query Expansion for conversational query reformulation"""
 
     def __init__(self, searcher: SimpleSearcher, settings: HqeSettings = HqeSettings()):
-        super().__init__("Hqe", verbose=settings.verbose)
-
+        super().__init__(name, verbose=settings.verbose)
+        self.name = name
         # Model settings
         self.M = settings.M
         self.eta = settings.eta

--- a/chatty_goose/settings.py
+++ b/chatty_goose/settings.py
@@ -1,14 +1,14 @@
 from pydantic import BaseSettings
-
+import typing
 from chatty_goose.types import PosFilter
 
-__all__ = ["SearcherSettings", "HqeSettings", "NtrSettings"]
+__all__ = ["SearcherSettings", "HqeSettings", "NtrSettings", "CqeSettings"]
 
 
 class SearcherSettings(BaseSettings):
     """Settings for Anserini searcher"""
 
-    index_path: str  # Pre-built index name or path to Lucene index
+    index_path: typing.Any  # Pre-built index name or path to Lucene index
     k1: float = 0.82  # BM25 k parameter
     b: float = 0.68  # BM25 b parameter
     rm3: bool = False  # use RM3
@@ -16,6 +16,11 @@ class SearcherSettings(BaseSettings):
     fb_docs: int = 10  # RM3 number of documents
     original_query_weight: float = 0.8  # RM3 weigh to assign initial query
 
+class DenseSearcherSettings(BaseSettings):
+    """Settings for Pyserini dsearcher"""
+
+    index_path: typing.Any # Pre-built index name or path to faiss index
+    query_encoder: str # path to huggingface model or hub
 
 class CqrSettings(BaseSettings):
     verbose: bool = False
@@ -29,6 +34,13 @@ class HqeSettings(CqrSettings):
     R_topic: float = 4.5  # topic keyword threshold
     R_sub: float = 3.5  # subtopic keyword threshold
     filter: PosFilter = PosFilter.POS  # 'no' or 'pos' or 'stp'
+
+class CqeSettings(CqrSettings):
+    """Settings for CQE model for NTR"""
+    l2_threshold: float = 10.5
+    model_name: str = "castorini/cqe"
+    max_context_length: int = 100
+    max_query_length: int = 36
 
 
 class NtrSettings(CqrSettings):

--- a/chatty_goose/types.py
+++ b/chatty_goose/types.py
@@ -8,5 +8,6 @@ class PosFilter(str, Enum):
 
 class CqrType(str, Enum):
     HQE = "hqe"
+    CQE = "cqe"
     T5 = "t5"
     FUSION = "fusion"

--- a/chatty_goose/types.py
+++ b/chatty_goose/types.py
@@ -11,3 +11,4 @@ class CqrType(str, Enum):
     CQE = "cqe"
     T5 = "t5"
     FUSION = "fusion"
+    CQE_T5_FUSION = "cqe_t5_fusion"

--- a/docs/conversation_dense_retrieval_experiments.md
+++ b/docs/conversation_dense_retrieval_experiments.md
@@ -14,7 +14,7 @@ export input_query_json=data/treccastweb/2019/data
 
 ## Run CQE retrieval
 
-The following command is for CQE, but you can also run other CQR methods using `t5` or `fusion` as the input to the `--experiment` flag (Currently, dense retrieval does not support HQE since it requires longer query sequence). Running the command for the first time will download the CAsT 2019 index (or whatever index is specified for the `--index` flag). It is also possible to supply a path to a local directory containing the index.
+The following command is for CQE, but you can also run other CQR methods using `t5` or `cqe_t5_fusion` as the input to the `--experiment` flag (Currently, dense retrieval does not support HQE since it requires longer query sequence). Running the command for the first time will download the CAsT 2019 index (or whatever index is specified for the `--index` flag). It is also possible to supply a path to a local directory containing the index.
 ### CQE BM25 Retrieval
 
 ```shell=bash
@@ -68,11 +68,11 @@ $path_to_anserini/tools/eval/trec_eval.9.0.4/trec_eval \
 Results for the CAsT 2019 evaluation dataset are provided below. The results may be slightly different from the numbers reported in the paper due to implementation differences between Huggingface and SpaCy versions. As of writing, we use `spacy==2.2.4` with the English model `en_core_web_sm==2.2.5`, and `transformers==4.0.0`. Note that the Recall@1000 reported in our paper are using rel greater than 2 but in the repo, to be consistent with other previous experiments, we use rel greater than 1.
 
 |             | CQE BM25 | CQE Dense Retrieval | CQE Hybrid | T5 BM25 | T5 Dense Retrieval | T5 Hybrid | CQE+T5 Fusion |
-| ----------- | :------: | :-------------: | :-------------:  :-----: | :------------: | :---------: | :----------------: |
-| mAP         |  0.2059  |     0.2616      |     0.2997      | 0.2250  |     0.2512     |   0.2584    |       0.3739       |
-| Recall@1000 |  0.7705  |     0.7248      |     0.7984      | 0.7392  |     0.6734     |   0.8028    |       0.8028       |
-| NDCG@1      |  0.3030  |     0.5082      |     0.4971      | 0.2842  |     0.4841     |   0.3353    |       0.5838       |
-| NDCG@3      |  0.2740  |     0.4924      |     0.5032      | 0.2954  |     0.4688     |   0.3247    |       0.5640       |
+| ----------- | :------: | :-------------: | :-------------: | :-----: | :------------: | :---------: | :----------------: |
+| mAP         |  0.2059  |     0.2616      |     0.2997      | 0.2250  |     0.2512     |   0.3043    |       0.3391       |
+| Recall@1000 |  0.7705  |     0.7248      |     0.7984      | 0.7392  |     0.6734     |   0.7856    |       0.8376       |
+| NDCG@1      |  0.3030  |     0.5082      |     0.4971      | 0.2842  |     0.4841     |   0.5077    |       0.5318       |
+| NDCG@3      |  0.2740  |     0.4924      |     0.5032      | 0.2954  |     0.4688     |   0.5065    |       0.5226       |
 
 ## Reproduction Log
 

--- a/docs/conversation_dense_retrieval_experiments.md
+++ b/docs/conversation_dense_retrieval_experiments.md
@@ -14,7 +14,7 @@ export input_query_json=data/treccastweb/2019/data
 
 ## Run CQE retrieval
 
-The following command is for CQE, but you can also run other CQR methods using `t5` or `cqe_t5_fusion` as the input to the `--experiment` flag (Currently, dense retrieval does not support HQE since it requires longer query sequence). Running the command for the first time will download the CAsT 2019 index (or whatever index is specified for the `--index` flag). It is also possible to supply a path to a local directory containing the index.
+The following command is for CQE, but you can also run other CQR methods using `t5` or `cqe_t5_fusion` as the input to the `--experiment` flag (Currently, dense retrieval does not support HQE since it requires longer query sequence). Running the command for the first time will download the CAsT 2019 index (or whatever index is specified for the `--index` flag). It is also possible to supply a path to a local directory containing the index. Note that now the hsw dense index is stored at Orca:store/scratch/s269lin/cast/indexes. So now just input the dense_index as absolute path.
 ### CQE BM25 Retrieval
 
 ```shell=bash

--- a/docs/conversation_dense_retrieval_experiments.md
+++ b/docs/conversation_dense_retrieval_experiments.md
@@ -1,0 +1,78 @@
+# Experiments for Conversational Dense Retrieval
+This is the Chatty-goose reproduction of our paper: *[Contextualized Query Embeddings for Conversational Search](https://arxiv.org/abs/2104.08707)* Sheng-Chieh Lin, Jheng-Hong Yang and Jimmy Lin. Note that, due to quey latency concern, different from our orginal paper and [CQE github](https://github.com/castorini/CQE), in this repo, we use HSW dense index; thus, the result may be slightly different.
+## Data Preparation
+
+1. Download either the [training](https://github.com/daltonj/treccastweb/blob/master/2019/data/training/train_topics_v1.0.json) and [evaluation](https://github.com/daltonj/treccastweb/blob/master/2019/data/evaluation/evaluation_topics_v1.0.json) input query JSON files. These files can be found under `data/treccastweb/2019/data` if you cloned the submodules for this repo.
+
+Pass your pathname to a variable
+default:
+```shell=bash
+export input_query_json=data/treccastweb/2019/data
+```
+
+2. Download the evaluation answer files for [training](https://github.com/daltonj/treccastweb/blob/master/2019/data/training/train_topics_mod.qrel) or [evaluation](https://trec.nist.gov/data/cast/2019qrels.txt). The training answer file is found under `data/treccastweb/2019/data`.
+
+## Run CQE retrieval
+
+The following command is for CQE, but you can also run other CQR methods using `t5` or `fusion` as the input to the `--experiment` flag (Currently, dense retrieval does not support HQE since it requires longer query sequence). Running the command for the first time will download the CAsT 2019 index (or whatever index is specified for the `--index` flag). It is also possible to supply a path to a local directory containing the index.
+### CQE BM25 Retrieval
+
+```shell=bash
+python -m experiments.run_retrieval \
+      --experiment cqe \
+      --index cast2019 \
+      --hits 1000 \
+      --qid_queries $input_query_json \
+      --output ./output/cqe_bm25 \
+```
+### CQE Dense Retrieval
+```shell=bash
+python -m experiments.run_retrieval \
+      --experiment cqe \
+      --dense_index=../cast/indexes \
+      --hits 1000 \
+      --qid_queries $input_query_json \
+      --output ./output/cqe_dpr \
+```
+### CQE Sparse-Dense Hybrid Retrieval
+```shell=bash
+python -m experiments.run_retrieval \
+      --experiment cqe \
+      --dense_index=../cast/indexes \
+      --index cast2019 \
+      --hits 1000 \
+      --qid_queries $input_query_json \
+      --output ./output/cqe_hybrid \
+      --cqe_l2_threshold 12 \
+```
+
+The experiment will output the retrieval results at the specified location in TSV format. By default, this will perform retrieval using only BM25, but you can add the `--rerank` flag to further rerank these results using BERT. For other command line arguments, see [run_retrieval.py](../experiments/run_retrieval.py).
+
+## Evaluate CQR results
+
+Convert the TSV file from above to TREC format and use the TREC tool to evaluate the resuls in terms of Recall@1000, mAP and NDCG@1,3.
+
+```shell=bash
+python $path_to_anserini/tools/scripts/msmarco/convert_msmarco_to_trec_run.py \
+      --input ./output/hqe_bm25.tsv \
+      --output ./output/hqe_bm25.trec
+
+$path_to_anserini/tools/eval/trec_eval.9.0.4/trec_eval \
+      -c -mrecall.1000 -mmap -mndcg_cut.1,3 \
+      ./output/answer_file \
+      ./output/hqe_bm25.trec
+```
+
+## Evaluation results
+
+Results for the CAsT 2019 evaluation dataset are provided below. The results may be slightly different from the numbers reported in the paper due to implementation differences between Huggingface and SpaCy versions. As of writing, we use `spacy==2.2.4` with the English model `en_core_web_sm==2.2.5`, and `transformers==4.0.0`. Note that the Recall@1000 reported in our paper are using rel greater than 2 but in the repo, to be consistent with other previous experiments, we use rel greater than 1.
+
+|             | CQE BM25 | CQE Dense Retrieval | CQE Hybrid | T5 BM25 | T5 Dense Retrieval | T5 Hybrid | CQE+T5 Fusion |
+| ----------- | :------: | :-------------: | :-------------:  :-----: | :------------: | :---------: | :----------------: |
+| mAP         |  0.2059  |     0.2616      |     0.2997      | 0.2250  |     0.2512     |   0.2584    |       0.3739       |
+| Recall@1000 |  0.7705  |     0.7248      |     0.7984      | 0.7392  |     0.6734     |   0.8028    |       0.8028       |
+| NDCG@1      |  0.3030  |     0.5082      |     0.4971      | 0.2842  |     0.4841     |   0.3353    |       0.5838       |
+| NDCG@3      |  0.2740  |     0.4924      |     0.5032      | 0.2954  |     0.4688     |   0.3247    |       0.5640       |
+
+## Reproduction Log
+

--- a/docs/conversation_dense_retrieval_experiments.md
+++ b/docs/conversation_dense_retrieval_experiments.md
@@ -45,8 +45,19 @@ python -m experiments.run_retrieval \
       --output ./output/cqe_hybrid \
       --cqe_l2_threshold 12 \
 ```
+### CQE fuse T5 Sparse-Dense Hybrid Retrieval
+```shell=bash
+python -m experiments.run_retrieval \
+      --experiment cqe_t5_fusion \
+      --dense_index=../cast/indexes \
+      --index cast2019 \
+      --hits 1000 \
+      --qid_queries $input_query_json \
+      --output ./output/cqe_t5_hybrid \
+      --cqe_l2_threshold 12 \
+```
 
-The experiment will output the retrieval results at the specified location in TSV format. By default, this will perform retrieval using only BM25, but you can add the `--rerank` flag to further rerank these results using BERT. For other command line arguments, see [run_retrieval.py](../experiments/run_retrieval.py).
+The experiment will output the retrieval results at the specified location in TSV format. For other command line arguments, see [run_retrieval.py](../experiments/run_retrieval.py).
 
 ## Evaluate CQR results
 
@@ -54,18 +65,18 @@ Convert the TSV file from above to TREC format and use the TREC tool to evaluate
 
 ```shell=bash
 python $path_to_anserini/tools/scripts/msmarco/convert_msmarco_to_trec_run.py \
-      --input ./output/hqe_bm25.tsv \
-      --output ./output/hqe_bm25.trec
+      --input ./output/cqe_t5_hybrid.tsv \
+      --output ./output/cqe_t5_hybrid.trec
 
 $path_to_anserini/tools/eval/trec_eval.9.0.4/trec_eval \
       -c -mrecall.1000 -mmap -mndcg_cut.1,3 \
       ./output/answer_file \
-      ./output/hqe_bm25.trec
+      ./output/cqe_t5_hybrid.trec
 ```
 
 ## Evaluation results
 
-Results for the CAsT 2019 evaluation dataset are provided below. The results may be slightly different from the numbers reported in the paper due to implementation differences between Huggingface and SpaCy versions. As of writing, we use `spacy==2.2.4` with the English model `en_core_web_sm==2.2.5`, and `transformers==4.0.0`. Note that the Recall@1000 reported in our paper are using rel greater than 2 but in the repo, to be consistent with other previous experiments, we use rel greater than 1.
+Results for the CAsT 2019 evaluation dataset are provided below. The results may be slightly different from the numbers reported in the paper due to implementation differences between Huggingface and SpaCy versions. As of writing, we use `spacy==2.2.4` with the English model `en_core_web_sm==2.2.5`, and `transformers==4.0.0`. Note that the Recall@1000 reported in [CQE paper]((https://arxiv.org/abs/2104.08707)) are using rel greater than 2 but in the repo, to be consistent with other previous experiments, we use rel greater than 1.
 
 |             | CQE BM25 | CQE Dense Retrieval | CQE Hybrid | T5 BM25 | T5 Dense Retrieval | T5 Hybrid | CQE+T5 Fusion |
 | ----------- | :------: | :-------------: | :-------------: | :-----: | :------------: | :---------: | :----------------: |

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -16,7 +16,7 @@ from pyserini.dsearch import SimpleDenseSearcher
 
 def parse_experiment_args():
     parser = argparse.ArgumentParser(description='CQR experiments for CAsT 2019.')
-    parser.add_argument('--experiment', type=str, help='Type of experiment (cqe, hqe, t5, fusion)')
+    parser.add_argument('--experiment', type=str, help='Type of experiment (cqe, hqe, t5, fusion, cqe_t5_fusion)')
     parser.add_argument('--qid_queries', required=True, default='', help='query id - query mapping file')
     parser.add_argument('--output', required=True, default='', help='output file')
     parser.add_argument('--index', default=None, help='bm25 index path')

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -16,7 +16,7 @@ from pyserini.dsearch import SimpleDenseSearcher
 
 def parse_experiment_args():
     parser = argparse.ArgumentParser(description='CQR experiments for CAsT 2019.')
-    parser.add_argument('--experiment', type=str, help='Type of experiment (hqe, t5, fusion)')
+    parser.add_argument('--experiment', type=str, help='Type of experiment (cqe, hqe, t5, fusion)')
     parser.add_argument('--qid_queries', required=True, default='', help='query id - query mapping file')
     parser.add_argument('--output', required=True, default='', help='output file')
     parser.add_argument('--index', default=None, help='bm25 index path')
@@ -162,7 +162,7 @@ if __name__ == "__main__":
         hqe_bm25 = Hqe(searcher, hqe_bm25_settings)
         reformulators.append(hqe_bm25)
 
-    if experiment == CqrType.T5 or experiment == CqrType.FUSION:
+    if experiment == CqrType.T5 or experiment == CqrType.FUSION or experiment == CqrType.CQE_T5_FUSION:
         # Initialize T5 NTR
         t5_settings = NtrSettings(
             model_name=args.t5_model_name,
@@ -184,7 +184,7 @@ if __name__ == "__main__":
         )
         reranker_query_reformulator = Hqe(searcher, hqe_bert_settings)
 
-    if experiment == CqrType.CQE:
+    if experiment == CqrType.CQE or experiment == CqrType.CQE_T5_FUSION:
         cqe_settings = CqeSettings(
             model_name=args.cqe_model_name,
             l2_threshold=args.cqe_l2_threshold,

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -67,7 +67,7 @@ def parse_experiment_args():
     args = parser.parse_args()
     return args
 
-    assert (args.index==None) and (args.dense_index==None)
+    
 
 def run_experiment(rp: RetrievalPipeline):
     with open(args.output + ".tsv", "w") as fout0:
@@ -125,6 +125,7 @@ def run_experiment(rp: RetrievalPipeline):
 
 if __name__ == "__main__":
     args = parse_experiment_args()
+    assert (args.index!=None) or (args.dense_index!=None), "Must input at least one index for search"
     experiment = CqrType(args.experiment)
 
     searcher_settings = SearcherSettings(

--- a/experiments/run_retrieval.py
+++ b/experiments/run_retrieval.py
@@ -1,22 +1,27 @@
+# Now we import pyserini directly from folder since input embeddings to SimpleDenseSearcher.search are not upgraded
+import sys 
+sys.path.append('../pyserini') 
 import argparse
 import json
 import time
 
-from chatty_goose.cqr import Hqe, Ntr
+from chatty_goose.cqr import Hqe, Ntr, Cqe
 from chatty_goose.pipeline import RetrievalPipeline
-from chatty_goose.settings import HqeSettings, SearcherSettings, NtrSettings
+from chatty_goose.settings import SearcherSettings, DenseSearcherSettings, HqeSettings, NtrSettings, CqeSettings
 from chatty_goose.types import CqrType, PosFilter
-from chatty_goose.util import build_bert_reranker, build_searcher
+from chatty_goose.util import build_bert_reranker, build_searcher, build_dense_searcher
 
 from pyserini.search import SimpleSearcher
-
+from pyserini.dsearch import SimpleDenseSearcher
 
 def parse_experiment_args():
     parser = argparse.ArgumentParser(description='CQR experiments for CAsT 2019.')
     parser.add_argument('--experiment', type=str, help='Type of experiment (hqe, t5, fusion)')
     parser.add_argument('--qid_queries', required=True, default='', help='query id - query mapping file')
     parser.add_argument('--output', required=True, default='', help='output file')
-    parser.add_argument('--index', required=True, default='', help='index path')
+    parser.add_argument('--index', default=None, help='bm25 index path')
+    parser.add_argument('--dense_index', default=None, help='dense index path')
+    parser.add_argument('--query_encoder', default='castorini/tct_colbert-v2-msmarco', help='query encoder model path')
     parser.add_argument('--hits', default=10, help='number of hits to retrieve')
     parser.add_argument('--rerank', action='store_true', help='rerank BM25 output using BERT')
     parser.add_argument('--reranker_device', default='cuda', help='reranker device to use')
@@ -51,10 +56,18 @@ def parse_experiment_args():
     parser.add_argument('--no_early_stopping', action='store_false', help='T5 disable early stopping')
     parser.add_argument('--t5_device', default='cuda', help='T5 device to use')
 
+    # Parameters for CQE
+    parser.add_argument('--cqe_model_name', default='castorini/tct_colbert-v2-msmarco-cqe', help='CQE model name')
+    parser.add_argument('--cqe_l2_threshold', default=10.5, help='Term weight threashold for select terms')
+    parser.add_argument('--cqe_max_context_length', default=100, help='CQE max context length')
+    parser.add_argument('--cqe_max_query_length', default=36, help='CQE max query length')
+    parser.add_argument('--cqe_device', default='cpu', help='CQE device to use')
+
     # Return args
     args = parser.parse_args()
     return args
 
+    assert (args.index==None) and (args.dense_index==None)
 
 def run_experiment(rp: RetrievalPipeline):
     with open(args.output + ".tsv", "w") as fout0:
@@ -123,7 +136,14 @@ if __name__ == "__main__":
         fb_docs=args.fb_docs,
         original_query_weight=args.original_query_weight,
     )
+
+    dense_searcher_settings = DenseSearcherSettings(
+        index_path=args.dense_index,
+        query_encoder=args.query_encoder,
+    )
+
     searcher = build_searcher(searcher_settings)
+    dense_searcher = build_dense_searcher(dense_searcher_settings)
 
     # Initialize CQR and reranker
     reformulators = []
@@ -164,11 +184,22 @@ if __name__ == "__main__":
         )
         reranker_query_reformulator = Hqe(searcher, hqe_bert_settings)
 
+    if experiment == CqrType.CQE:
+        cqe_settings = CqeSettings(
+            model_name=args.cqe_model_name,
+            l2_threshold=args.cqe_l2_threshold,
+            max_context_length=args.cqe_max_context_length,
+            max_query_length=args.cqe_max_query_length,
+            verbose=args.verbose,
+        )
+        cqe = Cqe(cqe_settings, device=args.cqe_device)
+        reformulators.append(cqe)
     # use context index for CAsT2020 data
     context_searcher = SimpleSearcher.from_prebuilt_index(args.context_index) if args.context_index else None
 
     rp = RetrievalPipeline(
         searcher,
+        dense_searcher,
         reformulators,
         searcher_num_hits=args.hits,
         early_fusion=not args.late_fusion,


### PR DESCRIPTION
New features added: (only for T5 and CQE, may consider HQE in the future)
(1) Dense retrieval 
(2) Dense-sparse hybrid retrieval

Some arg might be confused and may be changed in the future:
(1) --index, --dense_index: may change to --sparse_index and --dense_index
(2) --experiment now has options (hqe,cqe,t5,fusion,cqe_t5_fusion) may change to (hqe,cqe,t5,hqe_t5fusion,cqe_t5_fusion)